### PR TITLE
Backend: upgrade bcrypt package to at least v3

### DIFF
--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -222,12 +222,12 @@
       }
     },
     "bcrypt": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-2.0.0.tgz",
-      "integrity": "sha512-KL3nXU8H6QR/dgSUWHkjId5xIOJn8DTl4idFl720nsBwoq5ArAqIVmZ5BbD8LiCH+wjS7NX9hBvp30rGMmU0LA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-3.0.8.tgz",
+      "integrity": "sha512-jKV6RvLhI36TQnPDvUFqBEnGX9c8dRRygKxCZu7E+MgLfKZbmmXL8a7/SFFOyHoPNX9nV81cKRC5tbQfvEQtpw==",
       "requires": {
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.9.0"
+        "nan": "2.14.0",
+        "node-pre-gyp": "0.14.0"
       }
     },
     "bcrypt-pbkdf": {
@@ -1919,9 +1919,9 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "needle": {
       "version": "2.4.1",
@@ -1972,20 +1972,20 @@
       }
     },
     "node-pre-gyp": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.9.0.tgz",
-      "integrity": "sha1-vdTDr6ybGx6/8Kn/M2KFnrZ4G7g=",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz",
+      "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
-        "needle": "^2.2.0",
+        "needle": "^2.2.1",
         "nopt": "^4.0.1",
         "npm-packlist": "^1.1.6",
         "npmlog": "^4.0.2",
-        "rc": "^1.1.7",
+        "rc": "^1.2.7",
         "rimraf": "^2.6.1",
         "semver": "^5.3.0",
-        "tar": "^4"
+        "tar": "^4.4.2"
       }
     },
     "node-sass": {

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon server"
   },
   "dependencies": {
-    "bcrypt": "2.0.0",
+    "bcrypt": "^3.0.0",
     "body-parser": "^1.19.0",
     "chalk": "^2.4.2",
     "cookie-parser": "~1.4.4",


### PR DESCRIPTION
## Issue

I couldn't build the backend (using `npm install`) on OSX using Node v12.15.0.

## Fix

From what I gathered from [bcrypt's readme](https://github.com/kelektiv/node.bcrypt.js), the backend should use a more recent version of `bcrypt`:

Node Version | Bcrypt Version
-- | --
10, 11 | >= 3
12 | >= 3.0.6

After upgrading that `bcrypt` package, I could build the backend successfully.