### PR TITLE
status sent if empty fields

### DIFF
--- a/back-end/routes/register.js
+++ b/back-end/routes/register.js
@@ -28,7 +28,7 @@ module.exports = () => {
       avatar = 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png';
     }
     if (!username || !email || !password) {
-      res.send(EMPTY_ERROR)
+      res.status(401).send(EMPTY_ERROR)
     } else {
       checkIfUserExists(email).then(userCheck => {
         if (!userCheck) {


### PR DESCRIPTION
As per @cawel 's issue report, I have added a missing status response in `back-end/routes/register.js` line 31 when users do not enter their information correctly.