### PR TITLE
Fix/avatar src

### DIFF
--- a/back-end/db/seeds/01_users.sql
+++ b/back-end/db/seeds/01_users.sql
@@ -1,34 +1,34 @@
 INSERT INTO users (username, first_name, last_name, email, password, avatar, adventurer)
 VALUES
   (
-    'BobRobertson', 'Bob', 'Robertson', 'bob@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', true
+    'BobRobertson', 'Bob', 'Robertson', 'bob@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', true
   ),
   ( --2
-    'AlAlbertson', 'Al', 'Albertson', 'al@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', false
+    'AlAlbertson', 'Al', 'Albertson', 'al@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', false
   ),
   (
-    'SueSusanson', 'Sue', 'Susanson', 'sue@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', true
+    'SueSusanson', 'Sue', 'Susanson', 'sue@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', true
   ),
   (
-    'CingyMingus', 'Clinton', 'Andrews', 'drandrews@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', true
+    'CingyMingus', 'Clinton', 'Andrews', 'drandrews@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', true
   ),
   (
-    'Putem', 'Leeroy', 'Darling', 'darlingwriter@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', true
+    'Putem', 'Leeroy', 'Darling', 'darlingwriter@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', true
   ),
   ( -- 6
-    'MsSturgeon', 'Shae', 'Ramsay', 'sramsay@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', false
+    'MsSturgeon', 'Shae', 'Ramsay', 'sramsay@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', false
   ),
   (
-    'MalagdaMM', 'Robert', 'Rae', 'robertr@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', true
+    'MalagdaMM', 'Robert', 'Rae', 'robertr@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', true
   ),
   ( -- 8
-    'FrancisBob', 'Francis', 'Bob', 'fbob@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', false
+    'FrancisBob', 'Francis', 'Bob', 'fbob@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', false
   ),
   ( -- 9
-    'PouletLover', 'Bob', 'Judger', 'thejudger@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', false
+    'PouletLover', 'Bob', 'Judger', 'thejudger@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', false
   ),
   ( -- 10
-    'TP1990', 'Sarah', 'Palmer', 'sarah@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png', false
+    'TP1990', 'Sarah', 'Palmer', 'sarah@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', false
   );
   
 

--- a/back-end/routes/register.js
+++ b/back-end/routes/register.js
@@ -28,7 +28,7 @@ module.exports = () => {
       avatar = 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png';
     }
     if (!username || !email || !password) {
-      res.send(EMPTY_ERROR)
+      res.status(401).send(EMPTY_ERROR)
     } else {
       checkIfUserExists(email).then(userCheck => {
         if (!userCheck) {

--- a/back-end/routes/register.js
+++ b/back-end/routes/register.js
@@ -25,7 +25,7 @@ module.exports = () => {
       accountType = true;
     }
     if (!avatar) {
-      avatar = 'https://cdn.pixabay.com/photo/2016/08/08/09/17/avatar-1577909_960_720.png';
+      avatar = '/images/defaultAvatar.png';
     }
     if (!username || !email || !password) {
       res.status(401).send(EMPTY_ERROR)

--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -5,13 +5,13 @@ import BadgeBox from '../BadgeBox/BadgeBox';
 
 export default function Profile(props) {
 
-  const { username, first_name, last_name, email, adventurer } = props.state.userData;
+  const { username, first_name, last_name, email, adventurer, avatar } = props.state.userData;
   const { userBadges } = props.state;
 
   return (
     <section className='profile'>
       <h2>Your profile</h2>
-      <img alt="avatar" src="/images/defaultAvatar.png" />
+      <img alt="avatar" src={avatar} />
       <table className="table table-striped table-bordered">
         <tbody>
           <tr>


### PR DESCRIPTION
# changes

I replace all instances of the old URL we used with the pixel-art one. Notably in the users' seed DB, and in the register.js file as a default one when the avatar is not entered in the registration field.

Also, now the profile avatar is no longer hardcoded with our pixel-art default avatar, and thus allows users to show their avatar.