### PR TITLE
Add backend readme with instructions for running tests

### DIFF
--- a/back-end/README.md
+++ b/back-end/README.md
@@ -14,6 +14,6 @@ DB_PORT=
 
 And then:
 
-1. Create a test database which you can create using the psql client with `create database sidequests_tests;`
-2. If you've never run the tests for this project, seed the test database using `db/test_setup.sql`
+1. Create a test database, e.g. `create database sidequests_tests;` using the psql client
+2. Seed the test database from the root directory `\i back-end/db/test_setup` (note: this will drop your db tables if they already exist)
 3. Run `npm run test`

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -1,0 +1,19 @@
+# Backend
+
+## Tests
+
+In order to run the backend tests, you'll need a `.env.test` config file (not to be committed in git) inside the `back-end/` folder, e.g.:
+
+```
+DB_HOST=localhost
+DB_USER=quester
+DB_NAME=sidequests_tests
+DB_PASS=
+DB_PORT=
+```
+
+And then:
+
+1. Create a test database which you can create using the psql client with `create database sidequests_tests;`
+2. If you've never run the tests for this project, seed the test database using `db/test_setup.sql`
+3. Run `npm run test`


### PR DESCRIPTION
Since the backend is a project in itself, it makes sense to have a proper readme. Here is a start with instructions on how to run the tests.