### PR TITLE
Renames foreign-keys to default sequelize

### DIFF
--- a/back-end/db/helpers.js
+++ b/back-end/db/helpers.js
@@ -43,7 +43,7 @@ const getUserByUsername = function (username) {
 
 const classProgressForNewUser = function (userId) {
   const queryStr = `
-  INSERT INTO class_progress (class_id, adventurer_id, level, experience_points, quest_count)
+  INSERT INTO class_progress (classId, adventurer_id, level, experience_points, quest_count)
   VALUES
   (1, $1, 0, 0, 0),
   (2, $1, 0, 0, 0),
@@ -207,22 +207,15 @@ const createNewQuest = function (
   description,
   completed,
   city,
-  class_id,
+  classId,
   villager_id
 ) {
   const queryStr = `
-    INSERT INTO quests (name, description, completed, city, class_id, villager_id)
+    INSERT INTO quests (name, description, completed, city, classId, villager_id)
     VALUES ($1, $2, $3, $4, $5, $6);
   `;
   return db
-    .query(queryStr, [
-      name,
-      description,
-      completed,
-      city,
-      class_id,
-      villager_id,
-    ])
+    .query(queryStr, [name, description, completed, city, classId, villager_id])
     .then();
 };
 
@@ -246,7 +239,7 @@ const dropQuest = function (questId) {
 const editQuest = function (questId, name, description, completed, classId) {
   const queryStr = `
     UPDATE quests 
-    SET name = $1, description = $2, completed = $3, class_id = $4
+    SET name = $1, description = $2, completed = $3, "classId" = $4
     WHERE quests.id = $5;
   `;
   return db
@@ -300,7 +293,7 @@ const increaseClassLevel = function (userId, classId, amount) {
   const queryStr = `
     UPDATE class_progress
     SET level = level + $1
-    WHERE adventurer_id = $2 AND class_id = $3;
+    WHERE adventurer_id = $2 AND "classId" = $3;
   `;
 
   return db.query(queryStr, [amount, userId, classId]).then();
@@ -311,7 +304,7 @@ const setExperiencePoints = function (userId, classId, amount) {
   const queryStr = `
     UPDATE class_progress
     SET experience_points = $1
-    WHERE adventurer_id = $2 AND class_id = $3;
+    WHERE adventurer_id = $2 AND "classId" = $3;
   `;
   return db.query(queryStr, [amount, userId, classId]).then();
 };
@@ -320,7 +313,7 @@ const getClassProgress = function (userId, classId) {
   const queryStr = `
     SELECT * 
     FROM class_progress
-    WHERE adventurer_id = $1 AND class_id = $2;
+    WHERE adventurer_id = $1 AND "classId" = $2;
   `;
   return db.query(queryStr, [userId, classId]).then((res) => res.rows);
 };
@@ -329,7 +322,7 @@ const getAllBadgesForClass = function (classId) {
   const queryStr = `
     SELECT * 
     FROM badges
-    WHERE class_id = $1;
+    WHERE "classId" = $1;
   `;
   return db.query(queryStr, [classId]).then((res) => res.rows);
 };
@@ -338,7 +331,7 @@ const getUserBadgesByClass = function (userId, classId) {
   return getUserBadges(userId).then((userBadges) => {
     const classBadges = [];
     for (let i = 0; i < userBadges; i++) {
-      if (userBadges[i].class_id === classId) {
+      if (userBadges[i].classId === classId) {
         classBadges.push(userBadges[i]);
       }
     }
@@ -449,7 +442,7 @@ const levelUpCheck = function (userId, experiencePoints, classId) {
   });
 };
 
-const completeQuest = function (questId, adventurerId, class_id) {
+const completeQuest = function (questId, adventurerId, classId) {
   const queryStr = `
   UPDATE quests
   SET completed = true
@@ -459,8 +452,8 @@ const completeQuest = function (questId, adventurerId, class_id) {
   return db
     .query(queryStr, [questId])
     .then(() =>
-      increaseQuestCount(adventurerId, class_id, 1).then(() =>
-        levelUpCheck(adventurerId, 100, class_id)
+      increaseQuestCount(adventurerId, classId, 1).then(() =>
+        levelUpCheck(adventurerId, 100, classId)
       )
     );
 };
@@ -500,7 +493,7 @@ const getBadgesByClass = function (classId) {
   const queryStr = `
     SELECT *
     FROM badges
-    WHERE class_id = $1;
+    WHERE "classId" = $1;
   `;
   return db.query(queryStr, [classId]).then((res) => res.rows);
 };
@@ -518,7 +511,7 @@ const increaseQuestCount = function (userId, classId, amount) {
   const queryStr = `
   UPDATE class_progress
   SET quest_count = quest_count + $1
-  WHERE adventurer_id = $2 AND class_id = $3;
+  WHERE adventurer_id = $2 AND "classId" = $3;
   `;
 
   return db.query(queryStr, [amount, userId, classId]).then();

--- a/back-end/db/helpers.js
+++ b/back-end/db/helpers.js
@@ -208,14 +208,14 @@ const createNewQuest = function (
   completed,
   city,
   classId,
-  villager_id
+  villagerId
 ) {
   const queryStr = `
-    INSERT INTO quests (name, description, completed, city, classId, villager_id)
+    INSERT INTO quests (name, description, completed, city, classId, villagerId)
     VALUES ($1, $2, $3, $4, $5, $6);
   `;
   return db
-    .query(queryStr, [name, description, completed, city, classId, villager_id])
+    .query(queryStr, [name, description, completed, city, classId, villagerId])
     .then();
 };
 
@@ -284,7 +284,7 @@ const getQuestsByVillager = function (villagerId) {
   const queryStr = `
     SELECT * 
     FROM quests
-    WHERE villager_id = $1
+    WHERE "villagerId" = $1
   `;
   return db.query(queryStr, [villagerId]).then((res) => res.rows);
 };

--- a/back-end/db/helpers.js
+++ b/back-end/db/helpers.js
@@ -43,7 +43,7 @@ const getUserByUsername = function (username) {
 
 const classProgressForNewUser = function (userId) {
   const queryStr = `
-  INSERT INTO class_progress (classId, adventurer_id, level, experience_points, quest_count)
+  INSERT INTO class_progress (classId, adventurerId, level, experience_points, quest_count)
   VALUES
   (1, $1, 0, 0, 0),
   (2, $1, 0, 0, 0),
@@ -119,7 +119,7 @@ const checkUserQuests = function (userId) {
   const queryStr = `
     SELECT * 
     FROM quests
-    WHERE adventurer_id = $1
+    WHERE adventurerId = $1
   `;
   return db.query(queryStr, [userId]).then((res) => res.rows);
 };
@@ -128,7 +128,7 @@ const getAllUserClassProgress = function (userId) {
   const queryStr = `
     SELECT * 
     FROM class_progress
-    WHERE adventurer_id = $1
+    WHERE adventurerId = $1
   `;
   return db.query(queryStr, [userId]).then((res) => res.rows);
 };
@@ -230,7 +230,7 @@ const deleteQuest = function (questId) {
 const dropQuest = function (questId) {
   const queryStr = `
   UPDATE quests
-  SET adventurer_id = null
+  SET adventurerId = null
   WHERE id = $1;
   `;
   return db.query(queryStr, [questId]).then();
@@ -293,7 +293,7 @@ const increaseClassLevel = function (userId, classId, amount) {
   const queryStr = `
     UPDATE class_progress
     SET level = level + $1
-    WHERE adventurer_id = $2 AND "classId" = $3;
+    WHERE adventurerId = $2 AND "classId" = $3;
   `;
 
   return db.query(queryStr, [amount, userId, classId]).then();
@@ -304,7 +304,7 @@ const setExperiencePoints = function (userId, classId, amount) {
   const queryStr = `
     UPDATE class_progress
     SET experience_points = $1
-    WHERE adventurer_id = $2 AND "classId" = $3;
+    WHERE adventurerId = $2 AND "classId" = $3;
   `;
   return db.query(queryStr, [amount, userId, classId]).then();
 };
@@ -313,7 +313,7 @@ const getClassProgress = function (userId, classId) {
   const queryStr = `
     SELECT * 
     FROM class_progress
-    WHERE adventurer_id = $1 AND "classId" = $2;
+    WHERE adventurerId = $1 AND "classId" = $2;
   `;
   return db.query(queryStr, [userId, classId]).then((res) => res.rows);
 };
@@ -344,7 +344,7 @@ const unassignedBadgesForClass = function (userId, classId) {
     return getUserBadgesByClass(userId, classId).then((userBadges) => {
       for (let i = 0; i < badges.length; i++) {
         for (let y = 0; y < userBadges.length; y++) {
-          if ((badges[i].id = userBadges[y].badge_id)) {
+          if ((badges[i].id = userBadges[y].badgeId)) {
             badges.splice(i, 1);
           }
         }
@@ -356,7 +356,7 @@ const unassignedBadgesForClass = function (userId, classId) {
 
 const giveUserBadge = function (userId, badgeId) {
   const queryStr = `
-  INSERT INTO assigned_badges (adventurer_id, badge_id)
+  INSERT INTO assigned_badges (adventurerId, badgeId)
   VALUES
   ($1, $2);
   `;
@@ -415,7 +415,7 @@ const levelUpCheck = function (userId, experiencePoints, classId) {
   const queryStr = `
   SELECT *
   FROM class_progress
-  WHERE adventurer_id = $1;
+  WHERE adventurerId = $1;
   `;
   return db.query(queryStr, [userId]).then((res) => {
     if (
@@ -461,7 +461,7 @@ const completeQuest = function (questId, adventurerId, classId) {
 const acceptQuest = function (questId, userId) {
   const queryStr = `
   UPDATE quests
-  SET adventurer_id = $1
+  SET adventurerId = $1
   WHERE id = $2;
   `;
   return db.query(queryStr, [userId, questId]).then();
@@ -471,8 +471,8 @@ const getUserBadges = function (userId) {
   const queryStr = `
   SELECT * 
   FROM users 
-  JOIN assigned_badges on assigned_badges.adventurer_id = id 
-  JOIN badges on badges.id = assigned_badges.badge_id 
+  JOIN assigned_badges on assigned_badges.adventurerId = id 
+  JOIN badges on badges.id = assigned_badges.badgeId 
   WHERE users.id = $1;
   `;
   return db.query(queryStr, [userId]).then((res) => res.rows);
@@ -482,8 +482,8 @@ const getBadgesByUser = function (userId) {
   const queryStr = `
     SELECT badges.* 
     FROM badges 
-    JOIN assigned_badges on assigned_badges.badge_id = badges.id
-    JOIN users on users.id = assigned_badges.adventurer_id
+    JOIN assigned_badges on assigned_badges.badgeId = badges.id
+    JOIN users on users.id = assigned_badges.adventurerId
     WHERE users.id = $1;
   `;
   return db.query(queryStr, [userId]).then((res) => res.rows);
@@ -502,7 +502,7 @@ const getQuestsByAdventurer = function (userId) {
   const queryStr = `
     SELECT * 
     FROM quests
-    WHERE adventurer_id = $1;
+    WHERE adventurerId = $1;
   `;
   return db.query(queryStr, [userId]).then((res) => res.rows);
 };
@@ -511,7 +511,7 @@ const increaseQuestCount = function (userId, classId, amount) {
   const queryStr = `
   UPDATE class_progress
   SET quest_count = quest_count + $1
-  WHERE adventurer_id = $2 AND "classId" = $3;
+  WHERE adventurerId = $2 AND "classId" = $3;
   `;
 
   return db.query(queryStr, [amount, userId, classId]).then();

--- a/back-end/db/migrations/01_schema.sql
+++ b/back-end/db/migrations/01_schema.sql
@@ -35,9 +35,9 @@ CREATE TABLE quests (
   description TEXT NOT NULL,
   completed BOOLEAN NOT NULL DEFAULT FALSE,
   city VARCHAR(255) NOT NULL,
-  class_id INTEGER REFERENCES classes(id),
-  villager_id INTEGER REFERENCES users(id),
-  adventurer_id INTEGER REFERENCES users(id) DEFAULT NULL,
+  classId INTEGER REFERENCES classes(id),
+  villagerId INTEGER REFERENCES users(id),
+  adventurerId INTEGER REFERENCES users(id) DEFAULT NULL,
   experience_points INTEGER NOT NULL DEFAULT 100
 );
 
@@ -47,19 +47,19 @@ CREATE TABLE badges (
   requirement VARCHAR(255) NOT NULL,
   int_requirement INTEGER NOT NULL,
   criteria_type VARCHAR(255) NOT NULL,
-  class_id INTEGER REFERENCES classes(id) ON DELETE CASCADE NOT NULL
+  classId INTEGER REFERENCES classes(id) ON DELETE CASCADE NOT NULL
 );
 
 
 CREATE TABLE assigned_badges (
-  badge_id INTEGER REFERENCES badges(id) ON DELETE CASCADE NOT NULL,
-  adventurer_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL
+  badgeId INTEGER REFERENCES badges(id) ON DELETE CASCADE NOT NULL,
+  adventurerId INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL
 );
 
 
 CREATE TABLE class_progress (
-  class_id INTEGER REFERENCES classes(id) ON DELETE CASCADE NOT NULL,
-  adventurer_id INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
+  classId INTEGER REFERENCES classes(id) ON DELETE CASCADE NOT NULL,
+  adventurerId INTEGER REFERENCES users(id) ON DELETE CASCADE NOT NULL,
   level INTEGER DEFAULT 1,
   experience_points INTEGER DEFAULT 0,
   quest_count INTEGER DEFAULT 0

--- a/back-end/db/models/badges.js
+++ b/back-end/db/models/badges.js
@@ -1,7 +1,6 @@
 const sequelize = require("../sequelize");
 const { DataTypes } = require("sequelize");
 const Class = require("./classes");
-// const User = require("./users");
 
 const Badge = sequelize.define(
   "badge",
@@ -22,7 +21,7 @@ const Badge = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    class_id: {
+    classId: {
       type: DataTypes.INTEGER,
       references: {
         model: Class,

--- a/back-end/db/models/classProgress.js
+++ b/back-end/db/models/classProgress.js
@@ -6,7 +6,7 @@ const User = require("./users");
 const ClassProgress = sequelize.define(
   "class_progress",
   {
-    class_id: {
+    classId: {
       type: DataTypes.INTEGER,
       references: {
         model: Class,
@@ -14,7 +14,7 @@ const ClassProgress = sequelize.define(
       },
       allowNull: false,
     },
-    adventurer_id: {
+    adventurerId: {
       type: DataTypes.INTEGER,
       references: {
         model: User,

--- a/back-end/db/models/quests.js
+++ b/back-end/db/models/quests.js
@@ -23,7 +23,7 @@ const Quest = sequelize.define(
       type: DataTypes.STRING,
       allowNull: false,
     },
-    class_id: {
+    classId: {
       type: DataTypes.INTEGER,
       references: {
         model: Class,
@@ -31,7 +31,7 @@ const Quest = sequelize.define(
       },
       allowNull: false,
     },
-    adventurer_id: {
+    adventurerId: {
       type: DataTypes.INTEGER,
       references: {
         model: User,
@@ -39,7 +39,7 @@ const Quest = sequelize.define(
       },
       defaultValue: null,
     },
-    villager_id: {
+    villagerId: {
       type: DataTypes.INTEGER,
       references: {
         model: User,

--- a/back-end/db/models/relationships.js
+++ b/back-end/db/models/relationships.js
@@ -15,14 +15,9 @@ User.hasMany(Quest, { as: "villagerQuests" });
 
 User.hasMany(Quest, { as: "adventurerQuests" });
 
-ClassProgress.belongsTo(Class, {
-  foreignKey: "class_id",
-});
+ClassProgress.belongsTo(Class);
 
-ClassProgress.belongsTo(User, {
-  foreignKey: "adventurer_id",
-  as: "adventurer",
-});
+ClassProgress.belongsTo(User, { as: "adventurer" });
 
 AssignedBadge.belongsTo(Badge);
 

--- a/back-end/db/models/relationships.js
+++ b/back-end/db/models/relationships.js
@@ -11,9 +11,9 @@ Quest.belongsTo(User, { as: "adventurer" });
 
 Quest.belongsTo(Class);
 
-User.hasMany(Quest, { as: "villagerQuests" });
+User.hasMany(Quest, { foreignKey: "villagerId", as: "villagerQuests" });
 
-User.hasMany(Quest, { as: "adventurerQuests" });
+User.hasMany(Quest, { foreignKey: "adventurerId", as: "adventurerQuests" });
 
 ClassProgress.belongsTo(Class);
 

--- a/back-end/db/models/relationships.js
+++ b/back-end/db/models/relationships.js
@@ -5,29 +5,15 @@ const Class = require("./classes");
 const ClassProgress = require("./classProgress");
 const AssignedBadge = require("./assignedBadges");
 
-Quest.belongsTo(User, {
-  foreignKey: "villager_id",
-  as: "villager",
-});
+Quest.belongsTo(User, { as: "villager" });
 
-Quest.belongsTo(User, {
-  foreignKey: "adventurer_id",
-  as: "adventurer",
-});
+Quest.belongsTo(User, { as: "adventurer" });
 
-Quest.belongsTo(Class, {
-  foreignKey: "class_id",
-});
+Quest.belongsTo(Class);
 
-User.hasMany(Quest, {
-  foreignKey: "villager_id",
-  as: "villagerQuests",
-});
+User.hasMany(Quest, { as: "villagerQuests" });
 
-User.hasMany(Quest, {
-  foreignKey: "adventurer_id",
-  as: "adventurerQuests",
-});
+User.hasMany(Quest, { as: "adventurerQuests" });
 
 ClassProgress.belongsTo(Class, {
   foreignKey: "class_id",

--- a/back-end/db/models/relationships.js
+++ b/back-end/db/models/relationships.js
@@ -23,13 +23,9 @@ AssignedBadge.belongsTo(Badge);
 
 AssignedBadge.belongsTo(User);
 
-Badge.belongsTo(Class, {
-  foreignKey: "class_id",
-});
+Badge.belongsTo(Class);
 
-Class.hasMany(Badge, {
-  foreignKey: "class_id",
-});
+Class.hasMany(Badge);
 
 User.belongsToMany(Badge, { through: AssignedBadge });
 Badge.belongsToMany(User, { through: AssignedBadge });

--- a/back-end/db/seeds/03_badges.sql
+++ b/back-end/db/seeds/03_badges.sql
@@ -1,4 +1,4 @@
-INSERT INTO badges (name, requirement, int_requirement, criteria_type, class_id)
+INSERT INTO badges (name, requirement, int_requirement, criteria_type, classId)
 VALUES 
   (
     'A stealthy aquaintance',

--- a/back-end/db/seeds/04_assigned_badges.sql
+++ b/back-end/db/seeds/04_assigned_badges.sql
@@ -1,4 +1,4 @@
-INSERT INTO assigned_badges (adventurer_id, badge_id)
+INSERT INTO assigned_badges (adventurerId, badgeId)
 VALUES
   (1, 1),
   (1, 2),

--- a/back-end/db/seeds/05_class_progress.sql
+++ b/back-end/db/seeds/05_class_progress.sql
@@ -1,4 +1,4 @@
-INSERT INTO class_progress (class_id, adventurer_id, level, experience_points, quest_count)
+INSERT INTO class_progress (classId, adventurerId, level, experience_points, quest_count)
 VALUES
   (1, 1, 3, 300, 18),
   (2, 1, 3, 200, 5),

--- a/back-end/db/seeds/06_quests.sql
+++ b/back-end/db/seeds/06_quests.sql
@@ -1,4 +1,4 @@
-INSERT INTO quests (name, description, completed, city, class_id, villager_id)
+INSERT INTO quests (name, description, completed, city, classId, villagerId)
 VALUES
   ('Can''t figure out this math problem.', 'I have a test coming up and I can''t understand integrals.', false, 'Montreal', 3, 6),
   ('Need some soup', 'I''m sick and would really love some soup. I don''t want to go out and spread my virus.', false, 'Montreal', 6, 6),
@@ -13,7 +13,7 @@ VALUES
   ('My dog needs to take a walk', 'I broke my leg and my dog needs to take walks. Please help!', false, 'Montreal', 3, 9),
   ('Need pills from the pharmacy', 'I am out of medication and I need to take them ASAP', false, 'Montreal', 1, 2);
 
-INSERT INTO quests (name, description, completed, city, class_id, villager_id, adventurer_id)
+INSERT INTO quests (name, description, completed, city, classId, villagerId, adventurerId)
 VALUES
   ('Hungry for some soup!', 'I am at home and feeling very sick. Can someone bring me some some soup please?', true, 'Montreal', 6, 2, 1),
   ('My computer won''t start! Can someone help?', 'Ever since I installed this new app, my computer has been acting weird and won''t start', false, 'Montreal', 7, 2, 1);

--- a/back-end/db/seeds/test.sql
+++ b/back-end/db/seeds/test.sql
@@ -9,7 +9,7 @@ VALUES
   (
     'SueSusanson', 'Sue', 'Susanson', 'sue@example.com', '$2b$10$xPttDUv.c13m9X1ni9CqEOFk1P5exXZeq.2LL.YrztVIWMxi4FTVm', '/images/defaultAvatar.png', true, ''
   );
-INSERT INTO assigned_badges (adventurer_id, badge_id)
+INSERT INTO assigned_badges (adventurerId, badgeId)
 VALUES
   (1, 1),
   (1, 2),
@@ -17,7 +17,7 @@ VALUES
   (1, 7),
   (1, 8);
 
-INSERT INTO class_progress (class_id, adventurer_id, level, experience_points, quest_count)
+INSERT INTO class_progress (classId, adventurerId, level, experience_points, quest_count)
 VALUES
   (1, 1, 3, 300, 18),
   (2, 1, 3, 200, 5),
@@ -33,7 +33,7 @@ VALUES
   (5, 3, 4, 300, 3),
   (6, 3, 4, 300, 3);
 
-INSERT INTO quests (name, description, completed, city, class_id, villager_id, adventurer_id)
+INSERT INTO quests (name, description, completed, city, classId, villagerId, adventurerId)
 VALUES
   ('Hungry for some soup!', 'I am at home and feeling very sick. Can someone bring me some some soup please?', true, 'Montreal', 6, 2, 1),
   ('My computer won''t start! Can someone help?', 'Ever since I installed this new app, my computer has been acting weird and won''t start', false, 'Montreal', 7, 2, 1);

--- a/back-end/tests/endpoints.test.js
+++ b/back-end/tests/endpoints.test.js
@@ -45,7 +45,7 @@ describe("badges", () => {
 describe("classes", () => {
   beforeEach(async () => {
     classInstance = await createClass();
-    badge = await createBadge({ class_id: classInstance.id });
+    badge = await createBadge({ classId: classInstance.id });
   });
 
   it("should return an array of objects", async () => {
@@ -138,8 +138,8 @@ describe("quests", () => {
     adventurer = await createAdventurer();
     villager = await createVillager();
     quest = await createQuest({
-      adventurer_id: adventurer.id,
-      villager_id: villager.id,
+      adventurerId: adventurer.id,
+      villagerId: villager.id,
     });
   });
 

--- a/back-end/tests/endpoints.test.js
+++ b/back-end/tests/endpoints.test.js
@@ -173,3 +173,5 @@ describe("quests", () => {
     expect(specificQuest).toMatchObject(quest.dataValues);
   });
 });
+
+// /quests/:id/completeQuest/:classId

--- a/back-end/tests/models/badges.test.js
+++ b/back-end/tests/models/badges.test.js
@@ -14,13 +14,13 @@ let user2;
 describe("badges model", () => {
   beforeEach(async () => {
     classInstance = await createClass();
-    badge = await createBadge({ class_id: classInstance.id });
+    badge = await createBadge({ classId: classInstance.id });
   });
 
   it("can fetch associated class", async () => {
     const badgeForClass = await Badge.findByPk(badge.id);
     const classForBadge = await badgeForClass.getClass();
-    expect(classForBadge.id).toEqual(badge.class_id);
+    expect(classForBadge.id).toEqual(badge.classId);
   });
 
   describe("when badge has users", () => {

--- a/back-end/tests/models/classProgress.test.js
+++ b/back-end/tests/models/classProgress.test.js
@@ -11,8 +11,8 @@ describe("class progress model", () => {
     classInstance = await createClass();
     adventurer = await createAdventurer();
     classProgress = await createProgress({
-      adventurer_id: adventurer.id,
-      class_id: classInstance.id,
+      adventurerId: adventurer.id,
+      classId: classInstance.id,
     });
   });
 

--- a/back-end/tests/models/classes.test.js
+++ b/back-end/tests/models/classes.test.js
@@ -8,8 +8,8 @@ let badge2;
 describe("class model", () => {
   beforeEach(async () => {
     classInstance = await createClass();
-    badge1 = await createBadge({ class_id: classInstance.id });
-    badge2 = await createBadge({ class_id: classInstance.id });
+    badge1 = await createBadge({ classId: classInstance.id });
+    badge2 = await createBadge({ classId: classInstance.id });
   });
 
   it("can fetch the associated badges", async () => {

--- a/back-end/tests/models/quests.test.js
+++ b/back-end/tests/models/quests.test.js
@@ -18,8 +18,8 @@ describe("quest model", () => {
       villager = await createVillager();
       classInstance = await createClass();
       quest = await createQuest({
-        villager_id: villager.id,
-        class_id: classInstance.id,
+        villagerId: villager.id,
+        classId: classInstance.id,
       });
     });
 
@@ -44,9 +44,9 @@ describe("quest model", () => {
       adventurer = await createAdventurer();
       classInstance = await createClass();
       quest = await createQuest({
-        adventurer_id: adventurer.id,
-        villager_id: villager.id,
-        class_id: classInstance.id,
+        adventurerId: adventurer.id,
+        villagerId: villager.id,
+        classId: classInstance.id,
       });
     });
 

--- a/back-end/tests/models/users.test.js
+++ b/back-end/tests/models/users.test.js
@@ -56,31 +56,31 @@ describe("user model", () => {
       const questIds = adventurerQuests.map((q) => q.id).sort();
       expect(questIds).toEqual([quest1.id, quest2.id].sort());
     });
-  });
 
-  describe("when user has badges", () => {
-    beforeEach(async () => {
-      badge1 = await createBadge();
-      badge2 = await createBadge();
+    describe("when user has badges", () => {
+      beforeEach(async () => {
+        badge1 = await createBadge();
+        badge2 = await createBadge();
 
-      // associate those 2 badges to the adventurer
-      await createAssignedBadge({
-        userId: adventurer.id,
-        badgeId: badge1.id,
+        // associate those 2 badges to the adventurer
+        await createAssignedBadge({
+          userId: adventurer.id,
+          badgeId: badge1.id,
+        });
+        await createAssignedBadge({
+          userId: adventurer.id,
+          badgeId: badge2.id,
+        });
       });
-      await createAssignedBadge({
-        userId: adventurer.id,
-        badgeId: badge2.id,
+
+      it("can fetch the associated badges", async () => {
+        const adventurerUser = await User.findByPk(adventurer.id);
+        const badges = await adventurerUser.getBadges();
+
+        expect(badges.length).toEqual(2);
+        const badgeIds = badges.map((b) => b.id).sort();
+        expect(badgeIds).toEqual([badge1.id, badge2.id].sort());
       });
-    });
-
-    it("can fetch the associated badges", async () => {
-      const adventurerUser = await User.findByPk(adventurer.id);
-      const badges = await adventurerUser.getBadges();
-
-      expect(badges.length).toEqual(2);
-      const badgeIds = badges.map((b) => b.id).sort();
-      expect(badgeIds).toEqual([badge1.id, badge2.id].sort());
     });
   });
 });

--- a/back-end/tests/models/users.test.js
+++ b/back-end/tests/models/users.test.js
@@ -20,8 +20,8 @@ describe("user model", () => {
   describe("when user is a villager", () => {
     beforeEach(async () => {
       villager = await createVillager();
-      quest1 = await createQuest({ villager_id: villager.id });
-      quest2 = await createQuest({ villager_id: villager.id });
+      quest1 = await createQuest({ villagerId: villager.id });
+      quest2 = await createQuest({ villagerId: villager.id });
     });
 
     it("can fetch the associated quests", async () => {
@@ -39,12 +39,12 @@ describe("user model", () => {
       adventurer = await createAdventurer();
       villager = await createVillager();
       quest1 = await createQuest({
-        villager_id: villager.id,
-        adventurer_id: adventurer.id,
+        villagerId: villager.id,
+        adventurerId: adventurer.id,
       });
       quest2 = await createQuest({
-        villager_id: villager.id,
-        adventurer_id: adventurer.id,
+        villagerId: villager.id,
+        adventurerId: adventurer.id,
       });
     });
 
@@ -56,31 +56,31 @@ describe("user model", () => {
       const questIds = adventurerQuests.map((q) => q.id).sort();
       expect(questIds).toEqual([quest1.id, quest2.id].sort());
     });
+  });
 
-    describe("when user has badges", () => {
-      beforeEach(async () => {
-        badge1 = await createBadge();
-        badge2 = await createBadge();
+  describe("when user has badges", () => {
+    beforeEach(async () => {
+      badge1 = await createBadge();
+      badge2 = await createBadge();
 
-        // associate those 2 badges to the adventurer
-        await createAssignedBadge({
-          userId: adventurer.id,
-          badgeId: badge1.id,
-        });
-        await createAssignedBadge({
-          userId: adventurer.id,
-          badgeId: badge2.id,
-        });
+      // associate those 2 badges to the adventurer
+      await createAssignedBadge({
+        userId: adventurer.id,
+        badgeId: badge1.id,
       });
-
-      it("can fetch the associated badges", async () => {
-        const adventurerUser = await User.findByPk(adventurer.id);
-        const badges = await adventurerUser.getBadges();
-
-        expect(badges.length).toEqual(2);
-        const badgeIds = badges.map((b) => b.id).sort();
-        expect(badgeIds).toEqual([badge1.id, badge2.id].sort());
+      await createAssignedBadge({
+        userId: adventurer.id,
+        badgeId: badge2.id,
       });
+    });
+
+    it("can fetch the associated badges", async () => {
+      const adventurerUser = await User.findByPk(adventurer.id);
+      const badges = await adventurerUser.getBadges();
+
+      expect(badges.length).toEqual(2);
+      const badgeIds = badges.map((b) => b.id).sort();
+      expect(badgeIds).toEqual([badge1.id, badge2.id].sort());
     });
   });
 });

--- a/back-end/tests/seeds.js
+++ b/back-end/tests/seeds.js
@@ -47,7 +47,7 @@ const createQuest = async (options) =>
     description: faker.lorem.paragraph(),
     completed: false,
     city: faker.address.city(),
-    class_id: (await createClass()).id,
+    classId: (await createClass()).id,
     ...options,
   });
 

--- a/back-end/tests/seeds.js
+++ b/back-end/tests/seeds.js
@@ -57,7 +57,7 @@ const createBadge = async (options) =>
     requirement: "Complete 1 Rogue Quest",
     int_requirement: 1,
     criteria_type: "quest",
-    class_id: (await createClass()).id,
+    classId: (await createClass()).id,
     ...options,
   });
 

--- a/client/src/__mock__/data.js
+++ b/client/src/__mock__/data.js
@@ -67,8 +67,8 @@ const data = {
       completed: false,
       latitude: 330,
       longitude: 123,
-      class_id: 1,
-      villager_id: 1,
+      classId: 1,
+      villagerId: 1,
     },
     {
       id: 2,
@@ -78,8 +78,8 @@ const data = {
       completed: true,
       latitude: 330,
       longitude: 234,
-      class_id: 1,
-      villager_id: 1,
+      classId: 1,
+      villagerId: 1,
     },
     {
       id: 3,
@@ -88,8 +88,8 @@ const data = {
       completed: false,
       latitude: 321,
       longitude: 92,
-      class_id: 2,
-      villager_id: 1,
+      classId: 2,
+      villagerId: 1,
     },
     {
       id: 4,
@@ -98,8 +98,8 @@ const data = {
       completed: false,
       latitude: 321,
       longitude: 92,
-      class_id: 1,
-      villager_id: 1,
+      classId: 1,
+      villagerId: 1,
     },
   ],
 };

--- a/client/src/components/AllClasses/AllClasses.js
+++ b/client/src/components/AllClasses/AllClasses.js
@@ -6,7 +6,7 @@ export default function AllClasses(props) {
   const classProgress = props.classesProgressData.map(
     (classProgress, index) => {
       const currentClass = props.classesData.find(
-        (classData) => classData.id === classProgress.class_id
+        (classData) => classData.id === classProgress.classId
       );
       return (
         <div key={index} className="class-item">

--- a/client/src/components/Badge/Badge.js
+++ b/client/src/components/Badge/Badge.js
@@ -14,14 +14,14 @@ export default function Badge(props) {
       {props.locked ? (
         <img
           className="badgeImg locked"
-          alt={props.badge.class_id}
-          src={`/images/badges/${props.badge.class_id}.png`}
+          alt={props.badge.classId}
+          src={`/images/badges/${props.badge.classId}.png`}
         />
       ) : (
         <img
           className="badgeImg"
-          alt={props.badge.class_id}
-          src={`/images/badges/${props.badge.class_id}.png`}
+          alt={props.badge.classId}
+          src={`/images/badges/${props.badge.classId}.png`}
         />
       )}
       {popUp && (

--- a/client/src/components/ClassSelection/ClassSelection.js
+++ b/client/src/components/ClassSelection/ClassSelection.js
@@ -19,11 +19,11 @@ export default function ClassSelection(props) {
       (classData) => classData.name === name
     );
     const selectedClassProgress = props.state.classesProgressData.find(
-      (classProgress) => selectedClass.id === classProgress.class_id
+      (classProgress) => selectedClass.id === classProgress.classId
     );
     const selectedClassBadges =
       props.state.badges &&
-      props.state.badges.filter((badge) => badge.class_id === selectedClass.id);
+      props.state.badges.filter((badge) => badge.classId === selectedClass.id);
     setClassItem(selectedClass);
     setClassProgress(selectedClassProgress);
     setClassBadges(selectedClassBadges);
@@ -38,7 +38,7 @@ export default function ClassSelection(props) {
     axios.post(`/quests/${questId}/acceptQuest`).then(() => {
       const quests = props.state.userQuests.map((quest) => {
         if (quest.id === questId) {
-          quest.adventurer_id = props.state.userData.id;
+          quest.adventurerId = props.state.userData.id;
         }
         return quest;
       });
@@ -46,7 +46,7 @@ export default function ClassSelection(props) {
       const newQuest = props.state.userQuests.find(
         (quest) => quest.id === questId
       );
-      newQuest.adventurer_id = props.state.userData.id;
+      newQuest.adventurerId = props.state.userData.id;
       const newAdventurerQuests = [...props.state.questsByAdventurer, newQuest];
 
       props.setState((prevState) => ({

--- a/client/src/components/CreateQuest/CreateQuestForm.js
+++ b/client/src/components/CreateQuest/CreateQuestForm.js
@@ -22,9 +22,9 @@ export default function CreateQuestForm(props) {
           description: description,
           completed: false,
           city: city,
-          class_id: questType,
-          villager_id: props.state.userData.id,
-          adventurer_id: null,
+          classId: questType,
+          villagerId: props.state.userData.id,
+          adventurerId: null,
           experience_points: 100,
         };
         questsByVillager.push(newQuest);

--- a/client/src/components/GuestProfile/GuestProfile.js
+++ b/client/src/components/GuestProfile/GuestProfile.js
@@ -9,7 +9,7 @@ function VillagerQuests(props) {
   );
   const quests = props.state.userQuests
     .filter(
-      (quest) => quest.villager_id === props.villagerId && !quest.completed
+      (quest) => quest.villagerId === props.villagerId && !quest.completed
     )
     .map((quest, index) => {
       return (

--- a/client/src/components/Leaderboard/Leaderboard.js
+++ b/client/src/components/Leaderboard/Leaderboard.js
@@ -62,29 +62,29 @@ export default function Leaderboard(props) {
 
 const testClassData = [
   {
-    class_id: 1,
-    adventurer_id: 1,
+    classId: 1,
+    adventurerId: 1,
     level: 3,
     experience_points: 300,
     quest_count: 18,
   },
   {
-    class_id: 2,
-    adventurer_id: 1,
+    classId: 2,
+    adventurerId: 1,
     level: 3,
     experience_points: 200,
     quest_count: 5,
   },
   {
-    class_id: 3,
-    adventurer_id: 1,
+    classId: 3,
+    adventurerId: 1,
     level: 5,
     experience_points: 300,
     quest_count: 10,
   },
   {
-    class_id: 1,
-    adventurer_id: 1,
+    classId: 1,
+    adventurerId: 1,
     level: 3,
     experience_points: 300,
     quest_count: 23,

--- a/client/src/components/QuestList/QuestList.js
+++ b/client/src/components/QuestList/QuestList.js
@@ -14,11 +14,11 @@ export default function QuestList(props) {
       // the adventurer assigned must be either 3. yourself or 4. there are no adventurers assigned
       // 5. the villager who created the quest cannot be the current user (accout switch edge case)
       return (
-        quest.class_id === classItem.id && //1.
+        quest.classId === classItem.id && //1.
         !quest.completed && //2.
-        (quest.adventurer_id === userData.id || //3.
-          !quest.adventurer_id) && //4.
-        quest.villager_id !== userData.id //5.
+        (quest.adventurerId === userData.id || //3.
+          !quest.adventurerId) && //4.
+        quest.villagerId !== userData.id //5.
       );
     });
 
@@ -27,7 +27,7 @@ export default function QuestList(props) {
     validQuests.map((quest, index) => {
       const villager =
         villagers &&
-        villagers.find((villager) => villager.id === quest.villager_id);
+        villagers.find((villager) => villager.id === quest.villagerId);
       return (
         <QuestListItem
           // newUserCheck={props.newUserCheck}

--- a/client/src/components/QuestList/QuestListItem.js
+++ b/client/src/components/QuestList/QuestListItem.js
@@ -8,7 +8,7 @@ import axios from "axios";
 
 export default function QuestListItem(props) {
   // const [viewChat, setViewChat] = useState(false);
-  const { name, description, adventurer_id, city } = props.userQuests;
+  const { name, description, adventurerId, city } = props.userQuests;
   // const toggleChat = () => {
   //   if (viewChat) {
   //     setViewChat(false)
@@ -34,7 +34,7 @@ export default function QuestListItem(props) {
       <p>Location: {city}</p>
       <p>{description}</p>
       <footer className="quest-footer">
-        {adventurer_id && (
+        {adventurerId && (
           <div className="links btn btn-group">
             <a
               href="https://hangouts.google.com/call/4vTdHBEPZQ6TnGAwr570AEEE?no_rd"
@@ -48,7 +48,7 @@ export default function QuestListItem(props) {
             </a>
           </div>
         )}
-        {adventurer_id ? (
+        {adventurerId ? (
           <div className="check-container">
             <CheckSeal />
           </div>

--- a/client/src/components/TakenQuests/TakenQuestItem.js
+++ b/client/src/components/TakenQuests/TakenQuestItem.js
@@ -16,7 +16,7 @@ export default function TakenQuestItem(props) {
       );
       const newAllQuests = props.state.userQuests.map((quest) => {
         if (quest.id === questId) {
-          quest.adventurer_id = null;
+          quest.adventurerId = null;
         }
         return quest;
       });

--- a/client/src/components/TakenQuests/TakenQuests.js
+++ b/client/src/components/TakenQuests/TakenQuests.js
@@ -9,7 +9,7 @@ export default function TakenQuests(props) {
       .sort((a, b) => b.completed - a.completed)
       .map((quest, index) => {
         const villager = props.state.villagers.filter(
-          (villager) => quest.villager_id === villager.id
+          (villager) => quest.villagerId === villager.id
         );
         return (
           <TakenQuestItem

--- a/client/src/components/VillagerQuestList/VillagerQuestList.js
+++ b/client/src/components/VillagerQuestList/VillagerQuestList.js
@@ -9,9 +9,9 @@ export default function VillagerQuestList(props) {
       .sort((a, b) => b.completed - a.completed)
       .map((quest, index) => {
         const questAdventurer =
-          quest.adventurer_id &&
+          quest.adventurerId &&
           props.state.adventurers.find(
-            (adventurer) => adventurer.id === quest.adventurer_id
+            (adventurer) => adventurer.id === quest.adventurerId
           );
         return (
           <VillagerQuestListItem

--- a/client/src/components/VillagerQuestList/VillagerQuestListItem.js
+++ b/client/src/components/VillagerQuestList/VillagerQuestListItem.js
@@ -93,9 +93,9 @@ export default function QuestListItem(props) {
                   confirm
                   onClick={() =>
                     completeQuest(
-                      props.villagerQuest.class_id,
+                      props.villagerQuest.classId,
                       props.villagerQuest.id,
-                      props.villagerQuest.adventurer_id
+                      props.villagerQuest.adventurerId
                     )
                   }
                 >

--- a/client/src/stories/badge-hover.stories.js
+++ b/client/src/stories/badge-hover.stories.js
@@ -20,7 +20,7 @@ const badges = [
     requirement: "Complete 5 Alchemist Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 6,
+    classId: 6,
   },
   {
     id: 2,
@@ -30,7 +30,7 @@ const badges = [
     requirement: "Complete 5 Mage Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 5,
+    classId: 5,
   },
   {
     id: 3,
@@ -40,7 +40,7 @@ const badges = [
     requirement: "Complete 5 Monk Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 4,
+    classId: 4,
   },
   {
     id: 4,
@@ -50,7 +50,7 @@ const badges = [
     requirement: "Complete 5 Gadgeteer Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 7,
+    classId: 7,
   },
   {
     id: 5,
@@ -60,7 +60,7 @@ const badges = [
     requirement: "Complete 5 Rogue Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 1,
+    classId: 1,
   },
   {
     id: 6,
@@ -70,7 +70,7 @@ const badges = [
     requirement: "Complete 5 Druid Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 3,
+    classId: 3,
   },
   {
     id: 7,
@@ -80,6 +80,6 @@ const badges = [
     requirement: "Complete 5 Bard Quests",
     int_requirement: 5,
     criteria_type: "quest",
-    class_id: 2,
+    classId: 2,
   },
 ];

--- a/client/src/stories/class-progress.stories.js
+++ b/client/src/stories/class-progress.stories.js
@@ -1,12 +1,12 @@
-import React from 'react';
-import ClassProgress from '../components/ClassProgress/ClassProgress';
+import React from "react";
+import ClassProgress from "../components/ClassProgress/ClassProgress";
 
-// (class_id, adventurer_id, level, experience, quest_count)
+// (classId, adventurerId, level, experience, quest_count)
 const data = {
   id: 1,
   level: 2,
   experience: 100,
-  quest_count: 3
+  quest_count: 3,
 };
-export default {title: 'Class Progress'}
-export const classProgress = () => <ClassProgress data={data}/>
+export default { title: "Class Progress" };
+export const classProgress = () => <ClassProgress data={data} />;


### PR DESCRIPTION
# Notes:
* Some tests are now failing in `back-end/tests/endpoints.test.js`
```
badges
    ✓ should return an array of objects (49ms)
    ✓ should return a single badge object (18ms)
  classes
    ✓ should return an array of objects (20ms)
    ✓ should return a single class object (22ms)
    ✕ should return the badges associated with the specified class (17ms)
  users
    ✓ should return an array of all the user objects (25ms)
    ✓ should return a user with a specific id (11ms)
  villagers
    ✓ should return an array of villagers (14ms)
  adventurers
    ✓ should return an array of adventurers (11ms)
  quests
    ✓ should return an array of all the quests (23ms)
    ✓ should return a quest based on the quest id (24ms)
    ✕ should return quests based on the villager's id (23ms)
```
* some tests are now failing in `back-end/tests/models/users.tests.js

```
 FAIL  tests/models/users.test.js
  user model
    when user is a villager
      ✕ can fetch the associated quests (53ms)
    when user is an adventurer
      ✕ can fetch the associated quests (28ms)
    when user has badges
      ✓ can fetch the associated badges (32ms)
```


## To be done before merging

- [x] `01_schema.sql` updated
- [ ] backend server can start and uses the new db schema
- [ ] frontend is still functional (not broken)
- [ ] test added to make sure the route "/quests/:id/completeQuest/:classId" works as expected (thus testing the new `adventurerId` column name)